### PR TITLE
Slight modifications for portability

### DIFF
--- a/Script/Analysis_03_Scopus.R
+++ b/Script/Analysis_03_Scopus.R
@@ -1,8 +1,8 @@
 #
 # EDIT THESE DATA
 #
-fileread <- "C:\\Your\\File\\Path\\data--scopus.xlsx"
-fileToSave <- "C:\\Your\\File\\Path\\all-journals-scopus.csv"
+fileread <- "./Data/02_Scopus.xlsx"
+fileToSave <- "./Output/all-journals-scopus.csv"
 
 #
 # EXECUTABLE CODE STARTS HERE

--- a/Script/Analysis_06_Extract-Journals.R
+++ b/Script/Analysis_06_Extract-Journals.R
@@ -3,7 +3,7 @@
 # use the short name for that publisher in the 2nd column of the CSV-file,
 # and: ALL <- ALL[(ALL$PUBLISHER_FILENAME == "liverpool"), ] 
 
-ALL <- read.csv(".\\Data\\04_publishers.csv", header = T, sep = ";")
+ALL <- read.csv("./Data/04_publishers.csv", header = T, sep = ";", stringsAsFactors=FALSE)
 
 alljournals <- list()
 
@@ -11,7 +11,7 @@ alljournals <- list()
 # ALL <- ALL[(ALL$PUBLISHER_NAME) == "SAGE", ]
 
 # source the function getjournals()
-source(".\\Script\\Function\\function_getjournals.R")
+source("./Script/Function/function_getjournals.R")
 
 for (i in 1:nrow(ALL)) {
   alljournals[[i]] <- tryCatch(
@@ -34,7 +34,7 @@ DF <- unique(DF)
 
 currentDate <- Sys.Date()
 write.csv(DF,
-  file = paste0("Output//alljournals-", currentDate, ".csv"),
+  file = paste0("Output/alljournals-", currentDate, ".csv"),
   row.names = F
 )
 


### PR DESCRIPTION
I modified a few scripts to make them runnable on WSL:
- use forward slashes. This should be possible on the windows platform to. I only modified these scripts, the rest is not touched but could also benefit from similar changes
- some paths made relative instead of hardcoded from root/drive (e.g. C:\\some\\path to ../Data/)
- I needed to add "stringsAsFactors=FALSE" in the csv loader, otherwise the CSV would not be correctly loaded in step Analysis_06. Perhaps this is also a platform issue.